### PR TITLE
Implemented "Get a User's Storefront"

### DIFF
--- a/ASAppleMusic/Classes/ASAppleMusic.swift
+++ b/ASAppleMusic/Classes/ASAppleMusic.swift
@@ -123,12 +123,18 @@ public class ASAppleMusic {
         self.teamID = teamID
         self.tokenServer = tokenServer
     }
+    
+    func callWithToken(_ completion: @escaping (_ devToken: String?) -> Void) {
+        callWithToken { (devToken, nil) in
+            completion(devToken)
+        }
+    }
 
-    func callWithToken(_ completion: @escaping (_ token: String?) -> Void) {
+    func callWithToken(_ completion: @escaping (_ devToken: String?, _ userToken: String?) -> Void) {
         switch source {
         case .developer:
-            getDeveloperToken { token in
-                completion(token)
+            getDeveloperToken { devToken in
+                completion(devToken, nil)
             }
         case .user:
             getDeveloperToken { devToken in
@@ -136,20 +142,19 @@ public class ASAppleMusic {
                     let cloudService = SKCloudServiceController()
                     SKCloudServiceController.requestAuthorization { status in
                         if status == .authorized {
-                            cloudService.requestUserToken(forDeveloperToken: devToken,
-                                                          completionHandler: { userToken, error in
+                            cloudService.requestUserToken(forDeveloperToken: devToken, completionHandler: { (userToken, error) in
                                 if let userToken = userToken {
-                                    completion(userToken)
+                                    completion(devToken, userToken)
                                 } else {
-                                    completion(nil)
+                                    completion(devToken, nil)
                                 }
                             })
                         } else {
-                            completion(nil)
+                            completion(nil, nil)
                         }
                     }
                 } else {
-                    completion(nil)
+                    completion(nil, nil)
                 }
             }
         }

--- a/Example/ASAppleMusic/ASAppleMusic+Helper.swift
+++ b/Example/ASAppleMusic/ASAppleMusic+Helper.swift
@@ -7,6 +7,7 @@ import Foundation
 import ASAppleMusic
 
 enum CallType: String {
+    case getUserStorefront = "getUserStorefront"
     case getStorefront = "getStorefront"
     case getMultipleStorefronts = "getMultipleStorefronts"
     case getAllStorefronts = "getAllStorefronts"
@@ -40,6 +41,10 @@ extension ASAppleMusic {
     func makeCall(ofType type: CallType, withParams params: [String:String], _ completion: @escaping (AnyObject?, AMError?) -> Void) {
         switch type {
         // Storefronts
+        case .getUserStorefront:
+            ASAppleMusic.shared.getUserStorefront(withLang: params["l"], completion: { storefront, error in
+                completion(storefront, error)
+            })
         case .getStorefront:
             ASAppleMusic.shared.getStorefront(withID: params["id"]!, lang: params["l"], completion: { storefront, error in
                 completion(storefront, error)

--- a/Example/ASAppleMusic/AppDelegate.swift
+++ b/Example/ASAppleMusic/AppDelegate.swift
@@ -19,6 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             ASAppleMusic.shared.initialize(keyID: keyID, teamID: teamID, tokenServer: tokenServer)
         }
         ASAppleMusic.shared.debugLevel = .verbose
+        ASAppleMusic.shared.source = .user
 
         return true
     }

--- a/Example/ASAppleMusic/Sections.plist
+++ b/Example/ASAppleMusic/Sections.plist
@@ -125,18 +125,9 @@
 		<key>User Storefront</key>
 		<dict>
 			<key>function</key>
-			<string>getStorefront</string>
+			<string>getUserStorefront</string>
 			<key>params</key>
 			<dict>
-				<key>id</key>
-				<dict>
-					<key>name</key>
-					<string>ID</string>
-					<key>placeholder</key>
-					<string>us...</string>
-					<key>optional</key>
-					<false/>
-				</dict>
 				<key>l</key>
 				<dict>
 					<key>name</key>


### PR DESCRIPTION
- This is the first of the "/me" endpoints that requires the User Token
- Implemented it under the existing `User Storefront` screen removing the unnecessary ID field that was there
- User Token and Development Token are now passed properly as headers according to `curl -v -H 'Music-User-Token: [music user token]' -H 'Authorization: Bearer [developer token]' "https://api.music.apple.com/v1/me/storefront"
`
- Defaulting to .user as source